### PR TITLE
Increase timeout on database tasks ⏳

### DIFF
--- a/cypress/tests/ui/message.spec.js
+++ b/cypress/tests/ui/message.spec.js
@@ -1,6 +1,6 @@
 describe("Message Form", () => {
   beforeEach(() => {
-    cy.database("users").then((user) => {
+    cy.database("users", null, { timeout: 50000 }).then((user) => {
       cy.login(user.email, user.password);
     });
 

--- a/cypress/tests/ui/signup.spec.js
+++ b/cypress/tests/ui/signup.spec.js
@@ -3,7 +3,7 @@ const el = require("../../support/pages/register/elements").ELEMENTS;
 
 describe("Register Page", () => {
   beforeEach(function () {
-    cy.database("users").then((user) => {
+    cy.database("users", null, { timeout: 50000 }).then((user) => {
       cy.login(user.email, user.password);
       this.user = user;
     });

--- a/cypress/tests/ui/user-profile.spec.js
+++ b/cypress/tests/ui/user-profile.spec.js
@@ -1,7 +1,7 @@
 describe("User Profile", () => {
   beforeEach(function () {
     // seed database and login
-    cy.database("users").then((user) => {
+    cy.database("users", null, { timeout: 50000 }).then((user) => {
       cy.login(user.email, user.password);
     });
 


### PR DESCRIPTION
Increase timeout on cypress database custom commands because the Render-hosted API will spin down with inactivity, which can delay requests by 50 seconds or more.